### PR TITLE
feat: ヘルプページ実装

### DIFF
--- a/web/src/app/[lng]/help/guides/analytics/page.tsx
+++ b/web/src/app/[lng]/help/guides/analytics/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface AnalyticsGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.analytics.title'),
+    description: t('help.guides.analytics.description'),
+  };
+}
+
+export default async function AnalyticsGuide({ params }: AnalyticsGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="analytics"
+      title="help.guides.analytics.title"
+    />
+  );
+}

--- a/web/src/app/[lng]/help/guides/billing/page.tsx
+++ b/web/src/app/[lng]/help/guides/billing/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface BillingGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.billing.title'),
+    description: t('help.guides.billing.description'),
+  };
+}
+
+export default async function BillingGuide({ params }: BillingGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="billing"
+      title="help.guides.billing.title"
+    />
+  );
+}

--- a/web/src/app/[lng]/help/guides/getting-started/page.tsx
+++ b/web/src/app/[lng]/help/guides/getting-started/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface GettingStartedGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.gettingStarted.title'),
+    description: t('help.guides.gettingStarted.description'),
+  };
+}
+
+export default async function GettingStartedGuide({
+  params,
+}: GettingStartedGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="getting-started"
+      title="help.guides.gettingStarted.title"
+    />
+  );
+}

--- a/web/src/app/[lng]/help/guides/quiz-creation/page.tsx
+++ b/web/src/app/[lng]/help/guides/quiz-creation/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface QuizCreationGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.quizCreation.title'),
+    description: t('help.guides.quizCreation.description'),
+  };
+}
+
+export default async function QuizCreationGuide({
+  params,
+}: QuizCreationGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="quiz-creation"
+      title="help.guides.quizCreation.title"
+    />
+  );
+}

--- a/web/src/app/[lng]/help/guides/security/page.tsx
+++ b/web/src/app/[lng]/help/guides/security/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface SecurityGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.security.title'),
+    description: t('help.guides.security.description'),
+  };
+}
+
+export default async function SecurityGuide({ params }: SecurityGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="security"
+      title="help.guides.security.title"
+    />
+  );
+}

--- a/web/src/app/[lng]/help/guides/team-setup/page.tsx
+++ b/web/src/app/[lng]/help/guides/team-setup/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { GuideLayout } from '@/components/help/GuideLayout';
+
+interface TeamSetupGuideProps {
+  params: Promise<{ lng: string }>;
+}
+
+export async function generateMetadata({
+  params: { lng },
+}: {
+  params: { lng: string };
+}): Promise<Metadata> {
+  const t = await getTranslations({ locale: lng });
+
+  return {
+    title: t('help.guides.teamSetup.title'),
+    description: t('help.guides.teamSetup.description'),
+  };
+}
+
+export default async function TeamSetupGuide({ params }: TeamSetupGuideProps) {
+  const { lng } = await params;
+
+  return (
+    <GuideLayout
+      lng={lng}
+      guideId="team-setup"
+      title="help.guides.teamSetup.title"
+    />
+  );
+}

--- a/web/src/components/dashboard/SideNavigation.tsx
+++ b/web/src/components/dashboard/SideNavigation.tsx
@@ -96,11 +96,6 @@ export function SideNavigation({ lng }: SideNavigationProps) {
       icon: HelpCircle,
       label: t('navigation.help'),
     },
-    {
-      href: `/${lng}/help`,
-      icon: HelpCircle,
-      label: t('navigation.help'),
-    },
   ];
 
   return (

--- a/web/src/components/help/GuideLayout.tsx
+++ b/web/src/components/help/GuideLayout.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { ArrowLeft, Book, Clock, Users, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+
+interface GuideLayoutProps {
+  lng: string;
+  guideId: string;
+  title: string;
+}
+
+interface GuideStep {
+  id: string;
+  titleKey: string;
+  contentKey: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+const guideSteps: Record<string, GuideStep[]> = {
+  'getting-started': [
+    {
+      id: 'account',
+      titleKey: 'help.guides.gettingStarted.steps.account.title',
+      contentKey: 'help.guides.gettingStarted.steps.account.content',
+      icon: Users,
+    },
+    {
+      id: 'first-quiz',
+      titleKey: 'help.guides.gettingStarted.steps.firstQuiz.title',
+      contentKey: 'help.guides.gettingStarted.steps.firstQuiz.content',
+      icon: Book,
+    },
+    {
+      id: 'publish',
+      titleKey: 'help.guides.gettingStarted.steps.publish.title',
+      contentKey: 'help.guides.gettingStarted.steps.publish.content',
+      icon: CheckCircle,
+    },
+  ],
+  'quiz-creation': [
+    {
+      id: 'planning',
+      titleKey: 'help.guides.quizCreation.steps.planning.title',
+      contentKey: 'help.guides.quizCreation.steps.planning.content',
+      icon: Book,
+    },
+    {
+      id: 'questions',
+      titleKey: 'help.guides.quizCreation.steps.questions.title',
+      contentKey: 'help.guides.quizCreation.steps.questions.content',
+      icon: CheckCircle,
+    },
+    {
+      id: 'settings',
+      titleKey: 'help.guides.quizCreation.steps.settings.title',
+      contentKey: 'help.guides.quizCreation.steps.settings.content',
+      icon: Clock,
+    },
+  ],
+  'team-setup': [
+    {
+      id: 'create-team',
+      titleKey: 'help.guides.teamSetup.steps.createTeam.title',
+      contentKey: 'help.guides.teamSetup.steps.createTeam.content',
+      icon: Users,
+    },
+    {
+      id: 'invite-members',
+      titleKey: 'help.guides.teamSetup.steps.inviteMembers.title',
+      contentKey: 'help.guides.teamSetup.steps.inviteMembers.content',
+      icon: Users,
+    },
+    {
+      id: 'manage-roles',
+      titleKey: 'help.guides.teamSetup.steps.manageRoles.title',
+      contentKey: 'help.guides.teamSetup.steps.manageRoles.content',
+      icon: CheckCircle,
+    },
+  ],
+  analytics: [
+    {
+      id: 'overview',
+      titleKey: 'help.guides.analytics.steps.overview.title',
+      contentKey: 'help.guides.analytics.steps.overview.content',
+      icon: Book,
+    },
+    {
+      id: 'detailed-analysis',
+      titleKey: 'help.guides.analytics.steps.detailedAnalysis.title',
+      contentKey: 'help.guides.analytics.steps.detailedAnalysis.content',
+      icon: CheckCircle,
+    },
+    {
+      id: 'export-data',
+      titleKey: 'help.guides.analytics.steps.exportData.title',
+      contentKey: 'help.guides.analytics.steps.exportData.content',
+      icon: Clock,
+    },
+  ],
+  billing: [
+    {
+      id: 'plans',
+      titleKey: 'help.guides.billing.steps.plans.title',
+      contentKey: 'help.guides.billing.steps.plans.content',
+      icon: Book,
+    },
+    {
+      id: 'upgrade',
+      titleKey: 'help.guides.billing.steps.upgrade.title',
+      contentKey: 'help.guides.billing.steps.upgrade.content',
+      icon: CheckCircle,
+    },
+    {
+      id: 'manage-subscription',
+      titleKey: 'help.guides.billing.steps.manageSubscription.title',
+      contentKey: 'help.guides.billing.steps.manageSubscription.content',
+      icon: Clock,
+    },
+  ],
+  security: [
+    {
+      id: 'password-security',
+      titleKey: 'help.guides.security.steps.passwordSecurity.title',
+      contentKey: 'help.guides.security.steps.passwordSecurity.content',
+      icon: Users,
+    },
+    {
+      id: 'data-protection',
+      titleKey: 'help.guides.security.steps.dataProtection.title',
+      contentKey: 'help.guides.security.steps.dataProtection.content',
+      icon: CheckCircle,
+    },
+    {
+      id: 'privacy-settings',
+      titleKey: 'help.guides.security.steps.privacySettings.title',
+      contentKey: 'help.guides.security.steps.privacySettings.content',
+      icon: Clock,
+    },
+  ],
+};
+
+export function GuideLayout({ lng, guideId, title }: GuideLayoutProps) {
+  const t = useTranslations();
+  const steps = guideSteps[guideId] || [];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <Link href={`/${lng}/help`}>
+            <Button variant="ghost" className="mb-4">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t('help.backToHelp')}
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold text-gray-900">{t(title)}</h1>
+          <p className="mt-2 text-gray-600">
+            {t(`${title.replace('.title', '.description')}`)}
+          </p>
+        </div>
+
+        {/* Guide Content */}
+        <div className="grid gap-8 lg:grid-cols-3">
+          {/* Main Content */}
+          <div className="lg:col-span-2">
+            <div className="space-y-6">
+              {steps.map((step, index) => {
+                const Icon = step.icon || Book;
+                return (
+                  <Card key={step.id}>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-3">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100">
+                          <span className="text-sm font-medium text-blue-600">
+                            {index + 1}
+                          </span>
+                        </div>
+                        <Icon className="h-5 w-5 text-blue-600" />
+                        {t(step.titleKey)}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="prose prose-gray max-w-none">
+                        <p>{t(step.contentKey)}</p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+
+            {/* Next Steps */}
+            <Card className="mt-8 border-blue-200 bg-blue-50">
+              <CardHeader>
+                <CardTitle className="text-blue-900">
+                  {t('help.guides.nextSteps.title')}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="mb-4 text-blue-800">
+                  {t('help.guides.nextSteps.description')}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Link href={`/${lng}/dashboard`}>
+                    <Badge variant="secondary" className="hover:bg-blue-200">
+                      {t('help.guides.nextSteps.dashboard')}
+                    </Badge>
+                  </Link>
+                  <Link href={`/${lng}/help`}>
+                    <Badge variant="secondary" className="hover:bg-blue-200">
+                      {t('help.guides.nextSteps.moreHelp')}
+                    </Badge>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Sidebar */}
+          <div>
+            <Card className="sticky top-8">
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">
+                  {t('help.guides.onThisPage')}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <nav className="space-y-2">
+                  {steps.map((step, index) => (
+                    <a
+                      key={step.id}
+                      href={`#step-${step.id}`}
+                      className="block text-sm text-gray-600 hover:text-blue-600"
+                    >
+                      {index + 1}. {t(step.titleKey)}
+                    </a>
+                  ))}
+                </nav>
+                <Separator className="my-4" />
+                <div className="text-sm text-gray-500">
+                  <Clock className="mr-2 inline h-4 w-4" />
+                  {t('help.guides.estimatedTime')}: 5-10{' '}
+                  {t('help.guides.minutes')}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/data/help.ts
+++ b/web/src/data/help.ts
@@ -180,7 +180,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.gettingStarted.description',
       category: 'getting-started',
       icon: Book,
-      link: '#',
+      link: '/help/guides/getting-started',
     },
     {
       id: 'quiz-creation-guide',
@@ -188,7 +188,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.quizCreation.description',
       category: 'quiz-creation',
       icon: Zap,
-      link: '#',
+      link: '/help/guides/quiz-creation',
     },
     {
       id: 'team-setup-guide',
@@ -196,7 +196,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.teamSetup.description',
       category: 'team-management',
       icon: Users,
-      link: '#',
+      link: '/help/guides/team-setup',
     },
     {
       id: 'analytics-guide',
@@ -204,7 +204,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.analytics.description',
       category: 'analytics',
       icon: BarChart3,
-      link: '#',
+      link: '/help/guides/analytics',
     },
     {
       id: 'billing-guide',
@@ -212,7 +212,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.billing.description',
       category: 'billing',
       icon: CreditCard,
-      link: '#',
+      link: '/help/guides/billing',
     },
     {
       id: 'security-guide',
@@ -220,7 +220,7 @@ export const helpData: HelpData = {
       descriptionKey: 'help.guides.security.description',
       category: 'security',
       icon: Shield,
-      link: '#',
+      link: '/help/guides/security',
     },
   ],
   tutorials: [


### PR DESCRIPTION
## Summary
- Issue #238 MVP必須機能完了
- 6つのガイドページ実装 (getting-started, quiz-creation, team-setup, analytics, billing, security)
- GuideLayoutコンポーネント実装 - ステップバイステップナビゲーション
- ヘルプデータリンク更新 ('#' → 実際のパス)
- レスポンシブデザイン・日英両言語対応

## Test plan
- [ ] 全ガイドページが正常表示される
- [ ] ナビゲーションが正常動作する
- [ ] レスポンシブデザインが機能する
- [ ] 日英翻訳が適切に表示される

🤖 Generated with [Claude Code](https://claude.ai/code)